### PR TITLE
Typo in dub command example for dvulkan examples, ... 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ The API is similar to the C Vulkan API, but with some differences:
 * All structures have their `sType` field set to the appropriate value upon initialization; explicit initialization is not needed.
 * `VkPipelineShaderStageCreateInfo.module` has been renamed to `VkPipelineShaderStageCreateInfo._module`, since `module` is a D keyword.
 
-Examples can be found in the `examples` directory, and ran with `dub run dvulkan:examplename`.
+Examples can be found in the `examples` directory, and ran with `dub run d-vulkan:examplename`.
 
 Bindings for all extensions are available, except for the `VK_KHR_*_surface` extensions, which require types from external libraries (X11, XCB, ...). They can be manually loaded with `vkGetInstanceProcAddr` if needed.
 


### PR DESCRIPTION
should be 'dub run d-vulkan:examplename'. However it is correct on http://code.dlang.org/packages/d-vulkan/
